### PR TITLE
Switch Docker publish from GHCR to Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,15 +3,9 @@ name: Docker Build & Push
 on:
   push:
     branches: [ "main" ]
-    # 当推送类似于 v1.0.0 的版本标签时触发
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
-
-# 设置 GitHub Token 权限
-permissions:
-  contents: read
-  packages: write
 
 jobs:
   build-and-push:
@@ -25,25 +19,27 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # 2. 登录 GitHub 容器镜像服务 (GHCR)
-      - name: Log in to GitHub Container Registry
+      # 2. 登录到 Docker Hub
+      - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # 3. 自动生成镜像标签与元数据
+      # 3. 自动生成 Docker Hub 镜像标签与元数据
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          # 格式为: <你的DockerHub账号>/<镜像名>
+          # 例如: neotems/penshot
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/penshot
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=sha,prefix=sha-
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       # 4. 构建并推送镜像
       - name: Build and push Docker image
@@ -54,6 +50,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # 开启 GHA 缓存，大幅提速后续构建
+          # 开启 GHA 缓存，提速后续构建
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Updated Docker publish workflow to use Docker Hub instead of GitHub Container Registry, including changes to login credentials and image tagging.